### PR TITLE
Add support for reading packets with raw linktypes

### DIFF
--- a/src/passivedns.h
+++ b/src/passivedns.h
@@ -478,6 +478,7 @@ typedef struct _pdns_stat {
 typedef struct _globalconfig {
     pcap_t              *handle;         /* Pointer to libpcap handle */
     struct pcap_stat    ps;              /* libpcap stats */
+    int                 linktype;        /* libpcap linktype */
     pdns_stat           p_s;             /* pdns stats */
     struct bpf_program  cfilter;         /* */
     bpf_u_int32         net_mask;        /* */


### PR DESCRIPTION
In situations where packets are captured over an interface that does not have a specific data link layer like ethernet (such as a tunnel interface, or PCAP files made by tools like dnscap), passivedns wasn't able to read DNS traffic. This change allows captures over raw IP linktypes to work properly.
