### PR TITLE
Fix missing struct member 's6_addr32' on OSX

### DIFF
--- a/src/passivedns.h
+++ b/src/passivedns.h
@@ -77,9 +77,9 @@
 #define ERROR       1
 #define STDBUF      1024
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__APPLE__)
 #define s6_addr32   __u6_addr.__u6_addr32
-#endif /* __FreeBSD__ */
+#endif /* __FreeBSD__ or __APPLE__ */
 
 /*  D A T A  S T R U C T U R E S  *********************************************/
 


### PR DESCRIPTION
Like FreeBSD, `in6_addr` doesn't have a struct member called `s6_addr32` on Mac OS X.

This commit adds OSX to the controlled group that replaces `s6_addr32` with `__u6_addr.__u6_addr32`.

Prior to this commit, building on Mac OS X would throw this error:

```
dns.c:520:11: error: no member named 's6_addr32' in 'struct in6_addr'
         &IP4ADDR(&ip_addr),
          ^~~~~~~~~~~~~~~~~
./passivedns.h:294:28: note: expanded from macro 'IP4ADDR'
```
