### PR TITLE
Fixed redifinition warning (automake)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,7 +9,7 @@ all: $(bin_PROGRAMS)
 %.o: %.c
 	$(CC) -O3 $(CPPFLAGS) -c $< -o $@
 
-passivedns: $(OBJECTS)
+passivedns$(EXEEXT): $(OBJECTS)
 	$(CC) -o passivedns $(OBJECTS) $(LDFLAGS)
 
 clean:


### PR DESCRIPTION
Basically what the error message tells one to do:

```bash
$ autoreconf --install
src/Makefile.am:12: warning: deprecated feature: target 'passivedns' overrides 'passivedns$(EXEEXT)'
src/Makefile.am:12: change your target to read 'passivedns$(EXEEXT)'
/usr/share/automake-1.14/am/program.am: target 'passivedns$(EXEEXT)' was defined here
src/Makefile.am:5:   while processing program 'passivedns'
```
 
Tested on Ubuntu 14.04 with GNU Autoconf 2.69 and GNU Automake 1.14.1
