### PR TITLE
Initialize connections to SC_UNKNOWN vice SC_CLIENT

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -112,7 +112,7 @@ void dns_parser(packetinfo *pi)
         when running against millions of packet capture files, port resuse in the
         span of a few minutes is not uncommon.  This results in all subsequent
         responses on the reused port being thrown out as if they came from a client. */
-        if (pi->cxt->plid != ldns_pkt_id(dns_pkt) || pi->cxt->s_total_pkts == 0) {
+        if (pi->sc == SC_UNKNOWN || pi->cxt->s_total_pkts == 0) {
             dlog("[D] DNS Answer without a Question?: Query TID = %d and Answer TID = %d\n",
                  pi->cxt->plid, ldns_pkt_id(dns_pkt));
             ldns_pkt_free(dns_pkt);

--- a/src/dns.c
+++ b/src/dns.c
@@ -109,7 +109,7 @@ void dns_parser(packetinfo *pi)
         /* In situations where the first packet seen is a server response, the
         client/server determination is incorrectly marked as an SC_CLIENT session
         prior to the parsing of the DNS payload.  In high bandwidth data centers
-        when running against millions of packet capture files, port resuse in the
+        when running against millions of packet capture files, port reuse in the
         span of a few minutes is not uncommon.  This results in all subsequent
         responses on the reused port being thrown out as if they came from a client. */
         if (pi->sc == SC_UNKNOWN || pi->cxt->s_total_pkts == 0) {

--- a/src/passivedns.c
+++ b/src/passivedns.c
@@ -453,24 +453,29 @@ int connection_tracking(packetinfo *pi)
         if (af == AF_INET) {
             if (CMP_CXT4(cxt, IP4ADDR(ip_src), src_port, IP4ADDR(ip_dst), dst_port)) {
                 /* Client sends first packet (TCP/SYN - UDP?) hence this is a client */
+                dlog("[D] Found existing v4 client connection.\n");
                 return cxt_update_client(cxt, pi);
             }
             else if (CMP_CXT4(cxt, IP4ADDR(ip_dst), dst_port, IP4ADDR(ip_src), src_port)) {
                 /* This is a server (Maybe not when we start up but in the long run) */
+                dlog("[D] Found existing v4 server connection.\n");
                 return cxt_update_server(cxt, pi);
             }
         }
         else if (af == AF_INET6) {
             if (CMP_CXT6(cxt, ip_src, src_port, ip_dst, dst_port)) {
+                dlog("[D] Found existing v6 client connection.\n");
                 return cxt_update_client(cxt, pi);
             }
             else if (CMP_CXT6(cxt, ip_dst, dst_port, ip_src, src_port)) {
+                dlog("[D] Found existing v6 client connection.\n");
                 return cxt_update_server(cxt, pi);
             }
         }
         cxt = cxt->next;
     }
     /* Bucket turned upside down didn't yield anything. New connection */
+    dlog("[D] New connection.\n");
     cxt = cxt_new(pi);
 
     /* New connections are pushed on to the head of bucket[s_hash] */

--- a/src/passivedns.h
+++ b/src/passivedns.h
@@ -555,5 +555,6 @@ typedef struct _globalconfig {
 #endif
 
 int cxt_update_client(connection *cxt, packetinfo *pi);
+int cxt_update_unknown(connection *cxt, packetinfo *pi);
 int cxt_update_server(connection *cxt, packetinfo *pi);
 

--- a/src/passivedns.h
+++ b/src/passivedns.h
@@ -366,7 +366,7 @@ typedef struct _packetinfo {
     const struct pcap_pkthdr *pheader; /* Libpcap packet header struct pointer */
     const uint8_t   *packet;           /* Unsigned char pointer to raw packet */
     /* Compute (all) these from packet */
-    uint32_t        eth_hlen;         /* Ethernet header lenght */
+    uint32_t        eth_hlen;         /* Ethernet header length */
     uint16_t        mvlan;            /* Metro vlan tag */
     uint16_t        vlan;             /* VLAN tag */
     uint16_t        eth_type;         /* Ethernet type (IPv4/IPv6/etc) */
@@ -375,7 +375,7 @@ typedef struct _packetinfo {
     ether_arp       *arph;            /* ARP header struct pointer */
     ip4_header      *ip4;             /* IPv4 header struct pointer */
     ip6_header      *ip6;             /* IPv6 header struct pointer */
-    uint16_t        packet_bytes;     /* Lenght of IP payload in packet */
+    uint16_t        packet_bytes;     /* Length of IP payload in packet */
     uint16_t        s_port;           /* Source port */
     uint16_t        d_port;           /* Destination port */
     uint8_t         proto;            /* IP protocol type */

--- a/src/passivedns.h
+++ b/src/passivedns.h
@@ -379,7 +379,7 @@ typedef struct _packetinfo {
     uint16_t        s_port;           /* Source port */
     uint16_t        d_port;           /* Destination port */
     uint8_t         proto;            /* IP protocol type */
-    uint8_t         sc;               /* SC_SERVER or SC_CLIENT */
+    uint8_t         sc;               /* SC_SERVER, SC_CLIENT or SC_UNKNOWN */
     tcp_header      *tcph;            /* TCP header struct pointer */
     udp_header      *udph;            /* UDP header struct pointer */
     uint16_t        gre_hlen;         /* Length of dynamic GRE header length */
@@ -411,6 +411,7 @@ typedef struct _packetinfo {
 
 #define SC_CLIENT                 0x01  /* Pi for this session is client */
 #define SC_SERVER                 0x02  /* Pi for this session is server */
+#define SC_UNKNOWN                0x03  /* Pi for this session is not yet known */
 
 typedef struct _pdns_stat {
     uint32_t got_packets;    /* Number of packets received by program */


### PR DESCRIPTION
These changes attempt to deal with missing requests and responses caused by defaulting connections to an assumed client state.  It adds a new default state called SC_UNKNOWN at the transport layer and waits to make the SC_CLIENT/SC_SERVER determination until requests or responses are actually observed.