### PR TITLE
Add timestamp_first_s and timestamp_first_ms to JSON output

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -657,6 +657,8 @@ void print_passet(pdns_record *l, pdns_asset *p, ldns_rr *rr,
 
 #ifdef HAVE_JSON
     json_t *jdata;
+    json_t *json_timestamp_first_s;
+    json_t *json_timestamp_first_ms;
     json_t *json_timestamp_s;
     json_t *json_timestamp_ms;
     json_t *json_client;
@@ -855,6 +857,20 @@ void print_passet(pdns_record *l, pdns_asset *p, ldns_rr *rr,
     if ((is_err_record && config.use_json_nxd) ||
         (!is_err_record && config.use_json)) {
         jdata = json_object();
+
+        /* Print timestamp(s) */
+        if (config.fieldsf & FIELD_TIMESTAMP_FIRST_S) {
+            json_timestamp_first_s = json_integer(l->first_seen.tv_sec);
+            json_object_set(jdata, JSON_TIMESTAMP_FIRST_S, json_timestamp_first_s);
+            json_decref(json_timestamp_first_s);
+        }
+
+        /* Print timestamp(s) */
+        if (config.fieldsf & FIELD_TIMESTAMP_FIRST_MS) {
+            json_timestamp_first_ms = json_integer(l->first_seen.tv_usec);
+            json_object_set(jdata, JSON_TIMESTAMP_FIRST_MS, json_timestamp_first_ms);
+            json_decref(json_timestamp_first_ms);
+        }
 
         /* Print timestamp(s) */
         if (config.fieldsf & FIELD_TIMESTAMP_S) {

--- a/src/dns.h
+++ b/src/dns.h
@@ -60,17 +60,19 @@
 #define DNS_NXDOMAIN       0x01
 
 /* Flags for which fields to print */
-#define FIELD_TIMESTAMP_S  0x0001
-#define FIELD_TIMESTAMP_MS 0x0002
-#define FIELD_CLIENT       0x0004
-#define FIELD_SERVER       0x0008
-#define FIELD_CLASS        0x0010
-#define FIELD_QUERY        0x0020
-#define FIELD_TYPE         0x0040
-#define FIELD_ANSWER       0x0080
-#define FIELD_TTL          0x0100
-#define FIELD_COUNT        0x0200
-#define FIELD_TIMESTAMP_YMDHMS 0x0400
+#define FIELD_TIMESTAMP_FIRST_S  0x0001
+#define FIELD_TIMESTAMP_FIRST_MS 0x0002
+#define FIELD_TIMESTAMP_S        0x0004
+#define FIELD_TIMESTAMP_MS       0x0008
+#define FIELD_CLIENT             0x0010
+#define FIELD_SERVER             0x0020
+#define FIELD_CLASS              0x0040
+#define FIELD_QUERY              0x0080
+#define FIELD_TYPE               0x0100
+#define FIELD_ANSWER             0x0200
+#define FIELD_TTL                0x0400
+#define FIELD_COUNT              0x0800
+#define FIELD_TIMESTAMP_YMDHMS   0x0100
 
 /* Static values for print_passet() */
 #define PASSET_ERR_TTL     0
@@ -80,6 +82,8 @@
 #define PDNS_IDENT         "passivedns"
 
 /* JSON fields used when printing PDNS */
+#define JSON_TIMESTAMP_FIRST_S   "timestamp_first_s"
+#define JSON_TIMESTAMP_FIRST_MS   "timestamp_first_ms"
 #define JSON_TIMESTAMP_S   "timestamp_s"
 #define JSON_TIMESTAMP_MS  "timestamp_ms"
 #define JSON_CLIENT        "client"

--- a/src/passivedns.c
+++ b/src/passivedns.c
@@ -1166,6 +1166,8 @@ int main(int argc, char *argv[])
     config.log_delimiter = "||";
     config.fieldsf = 0;
     /* config.fieldsf |= FIELD_TIMESTAMP_YMDHMS; /* not on by default  */
+    config.fieldsf |= FIELD_TIMESTAMP_FIRST_S;
+    config.fieldsf |= FIELD_TIMESTAMP_FIRST_MS;
     config.fieldsf |= FIELD_TIMESTAMP_S;
     config.fieldsf |= FIELD_TIMESTAMP_MS;
     config.fieldsf |= FIELD_CLIENT;


### PR DESCRIPTION
In addition to the existing timestamp_s and timestamp_ms, which represents "last seen", adding "first seen" to the JSON output will help to keep timestamps in order.