### PR TITLE
Added automake to OS X dependencies

### DIFF
--- a/doc/INSTALL
+++ b/doc/INSTALL
@@ -16,7 +16,7 @@ FreeBSD Install
   $ gmake
 
 OS X (using Homebrew for dependencies)
-  $ brew install autoconf ldns jansson
+  $ brew install automake autoconf ldns jansson
   $ git clone git://github.com/gamelinux/passivedns.git
   $ cd passivedns/
   $ autoreconf --install


### PR DESCRIPTION
I also needed to install `automake` because some `autoconf` scripts require `aclocal`:

```
> passivedns git:(master) autoreconf --install
Can't exec "aclocal": No such file or directory at /usr/local/Cellar/autoconf/2.69/share/autoconf/Autom4te/FileUtils.pm line 326.
autoreconf: failed to run aclocal: No such file or directory
```