### PR TITLE
Print rcode=0(NOERR) responses (name exists but no answer data).

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -281,7 +281,7 @@ int cache_dns_objects(packetinfo *pi, ldns_rdf *rdf_data,
         dlog("[D] dns_answer_domain_cnt: %d\n",dns_answer_domain_cnt);
     }
 
-    if (dns_answer_domain_cnt == 0 && ldns_pkt_get_rcode(dns_pkt) != 0) {
+    if ((dns_answer_domain_cnt == 0) && ((config.dnsfe & DNS_SE_CHK_NOERR) || (ldns_pkt_get_rcode(dns_pkt) != 0))) {
         uint16_t rcode = ldns_pkt_get_rcode(dns_pkt);
         dlog("[D] Error return code: %d\n", rcode);
 
@@ -827,7 +827,10 @@ void print_passet(pdns_record *l, pdns_asset *p, ldns_rr *rr,
 
     if (is_err_record) {
         switch (rcode) {
-            case 1:
+            case 0:
+                snprintf(rr_rcode, 20, "NOERROR");
+                break;
+             case 1:
                 snprintf(rr_rcode, 20, "FORMERR");
                 break;
             case 2:
@@ -1697,6 +1700,11 @@ void parse_dns_flags(char *args)
                dlog("[D] Enabling flag: DNS_SE_CHK_NOTZONE\n");
                ok++;
                break;
+            case '0': /* NOERR */
+               config.dnsfe |= DNS_SE_CHK_NOERR;
+               dlog("[D] Enabling flag: DNS_SE_CHK_NOERR\n");
+               ok++;
+               break;
             case '\0':
                dlog("[W] Bad DNS flag - ending flag checks!\n");
                ok = 0;
@@ -1718,6 +1726,9 @@ uint16_t pdns_chk_dnsfe(uint16_t rcode)
     uint16_t retcode = 0x0000;
 
     switch (rcode) {
+        case 0:
+            retcode = DNS_SE_CHK_NOERR;
+            break;
         case 1:
             retcode = DNS_SE_CHK_FORMERR;
             break;

--- a/src/dns.h
+++ b/src/dns.h
@@ -54,6 +54,7 @@
 #define DNS_SE_CHK_NXRRSET  0x0080
 #define DNS_SE_CHK_NOTAUTH  0x0100
 #define DNS_SE_CHK_NOTZONE  0x0200
+#define DNS_SE_CHK_NOERR    0x0400
 #define DNS_SE_CHK_ALL      0x8000
 
 /* Flag for indicating an NXDOMAIN */

--- a/src/passivedns.c
+++ b/src/passivedns.c
@@ -1121,6 +1121,7 @@ void usage()
     olog(" * For Server Return Code (SRC) Errors:\n");
     olog("   f:FORMERR   s:SERVFAIL  x:NXDOMAIN  o:NOTIMPL  r:REFUSED\n");
     olog("   y:YXDOMAIN  e:YXRRSET   t:NXRRSET   a:NOTAUTH  z:NOTZONE\n");
+    olog("   0:NOERR\n");
     olog("\n");
 }
 


### PR DESCRIPTION
Log NOERR answers with -X 0
(example: dig SRV example.com should log something like this:
1455559265.4295281459||ip.add.re.ss||ip.add.re.ss||IN||example.com.||SRV||NOERROR||0||1)