### PR TITLE
add support for print Server IP TTL

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -567,6 +567,7 @@ void update_pdns_record_asset(packetinfo *pi, pdns_record *pr,
                 passet->af        = pi->cxt->af;
                 passet->cip       = pi->cxt->s_ip; /* This should always be the client IP */
                 passet->sip       = pi->cxt->d_ip; /* This should always be the server IP */
+                passet->sip_ttl   = pi->s_ttl; /* This should always be the server V4/v6 IP */
                 if (rr->_ttl > passet->rr->_ttl)
                         passet->rr->_ttl = rr->_ttl;   /* Catch the highest TTL seen */
                 dlog("[*] DNS asset updated...\n");
@@ -611,6 +612,7 @@ void update_pdns_record_asset(packetinfo *pi, pdns_record *pr,
     passet->af = pi->cxt->af;
     passet->cip = pi->cxt->s_ip; /* This should always be the client IP */
     passet->sip = pi->cxt->d_ip; /* This should always be the server IP */
+    passet->sip_ttl = pi->s_ttl; /* This should always be the server IP TTL */
     passet->prev = NULL;
     len = strlen((char *)rdomain_name);
     passet->answer = calloc(1, (len + 1));
@@ -648,6 +650,7 @@ void print_passet(pdns_record *l, pdns_asset *p, ldns_rr *rr,
     FILE *fd = NULL;
     static char ip_addr_s[INET6_ADDRSTRLEN];
     static char ip_addr_c[INET6_ADDRSTRLEN];
+    uint8_t ip_addr_s_ttl ;
     char *d = config.log_delimiter;
     char *proto;
     char *rr_class;
@@ -666,6 +669,7 @@ void print_passet(pdns_record *l, pdns_asset *p, ldns_rr *rr,
     json_t *json_client;
     json_t *json_server;
     json_t *json_proto;
+    json_t *json_server_ttl;
     json_t *json_class;
     json_t *json_query;
     json_t *json_query_len;
@@ -704,12 +708,13 @@ void print_passet(pdns_record *l, pdns_asset *p, ldns_rr *rr,
     if (is_err_record) {
         u_ntop(l->sip, l->af, ip_addr_s);
         u_ntop(l->cip, l->af, ip_addr_c);
+        ip_addr_s_ttl=l->sip_ttl;
     }
     else {
         u_ntop(p->sip, p->af, ip_addr_s);
         u_ntop(p->cip, p->af, ip_addr_c);
+        ip_addr_s_ttl=p->sip_ttl;
     }
-
     proto    = malloc(4);
     rr_class = malloc(10);
     rr_type  = malloc(12);
@@ -906,6 +911,13 @@ void print_passet(pdns_record *l, pdns_asset *p, ldns_rr *rr,
             json_decref(json_server);
         }
 
+        /* Print server IP  TTL*/
+        if (config.fieldsf & FIELD_SERVER_TTL) {
+            json_server_ttl = json_string(ip_addr_s_ttl);
+            json_object_set(jdata, json_server_ttl, json_server_ttl);
+            json_decref(json_server_ttl);
+        }
+
         /* Print protocol */
         if (config.fieldsf & FIELD_PROTO) {
             json_proto = json_string(proto);
@@ -1063,6 +1075,12 @@ void print_passet(pdns_record *l, pdns_asset *p, ldns_rr *rr,
             offset += snprintf(output+offset, sizeof(buffer) - offset, "%s", ip_addr_s);
         }
 
+        /* Print Server IP  TTL */
+        if (config.fieldsf & FIELD_SERVER_TTL) {
+            if (offset != 0)
+                offset += snprintf(output+offset, sizeof(buffer) - offset, "%s", d);
+            offset += snprintf(output+offset, sizeof(buffer) - offset, "%d", ip_addr_s_ttl);
+        }
         /* Print protocol */
         if (config.fieldsf & FIELD_PROTO) {
             if (offset != 0)
@@ -1197,6 +1215,7 @@ pdns_record *get_pdns_record(uint64_t dnshash, packetinfo *pi,
             pdnsr->af = pi->cxt->af;
             pdnsr->cip = pi->cxt->s_ip; /* This should always be the client IP */
             pdnsr->sip = pi->cxt->d_ip; /* This should always be the server IP */
+            pdnsr->sip_ttl = pi->s_ttl; /* This should always be the server IP TTL */
             return pdnsr;
         }
         pdnsr = pdnsr->next;
@@ -1219,6 +1238,7 @@ pdns_record *get_pdns_record(uint64_t dnshash, packetinfo *pi,
     pdnsr->nxflag = 0;
     pdnsr->cip = pi->cxt->s_ip; /* This should always be the client IP */
     pdnsr->sip = pi->cxt->d_ip; /* This should always be the server IP */
+    pdnsr->sip_ttl = pi->s_ttl; /* This should always be the server IP ttl */
     pdnsr->next = head;
     pdnsr->prev = NULL;
     pdnsr->passet = NULL;
@@ -1567,6 +1587,11 @@ void parse_field_flags(char *args)
             case 'T': /* Type */
                 config.fieldsf |= FIELD_TYPE;
                 dlog("[D] Enabling field: FIELD_TYPE\n");
+                ok++;
+                break;
+            case 'i': /* IP heder TTL */
+                config.fieldsf |= FIELD_SERVER_TTL;
+                dlog("[D] Enabling field: FIELD_SERVER_TTL\n");
                 ok++;
                 break;
             case 'A': /* Answer */

--- a/src/dns.h
+++ b/src/dns.h
@@ -75,6 +75,7 @@
 #define FIELD_HOSTNAME     0x1000
 #define FIELD_QUERY_LEN    0x2000
 #define FIELD_ANSWER_LEN   0x4000
+#define FIELD_SERVER_TTL   0x8000
 
 /* Static values for print_passet() */
 #define PASSET_ERR_TTL     0
@@ -98,6 +99,7 @@
 #define JSON_TTL           "ttl"
 #define JSON_COUNT         "count"
 #define JSON_HOSTNAME      "hostname"
+#define JSON_SERVER_TTL    "server_ttl"
 
 /* To avoid spaming the logfile with duplicate dns info
  * we only print a dns record one time each 24H. This way
@@ -137,6 +139,7 @@ typedef struct _pdns_asset {
     uint32_t               af;         /* IP version (4/6) AF_INET */
     struct in6_addr        sip;        /* DNS Server IP (v4/6) */
     struct in6_addr        cip;        /* DNS Client IP (v4/6) */
+    uint8_t                sip_ttl;    /* DNS Server IP ttl(v4/6)*/
     struct _pdns_asset     *next;      /* Next dns asset */
     struct _pdns_asset     *prev;      /* Prev dns asset */
 } pdns_asset;
@@ -151,6 +154,7 @@ typedef struct _pdns_record {
     uint32_t               af;         /* IP version (4/6) AF_INET */
     struct in6_addr        sip;        /* DNS Server IP (v4/6) */
     struct in6_addr        cip;        /* DNS Client IP (v4/6) */
+    uint8_t                sip_ttl;    /* DNS Server IP ttl(v4/6)*/
     uint8_t                proto;      /* Protocol */
     pdns_asset             *passet;    /* Head of dns assets */
     struct _pdns_record    *next;      /* Next dns record */

--- a/src/passivedns.c
+++ b/src/passivedns.c
@@ -231,6 +231,7 @@ void prepare_ip4(packetinfo *pi)
     pi->af = AF_INET;
     pi->ip4 = (ip4_header *) (pi->packet + pi->eth_hlen);
     pi->packet_bytes = (pi->ip4->ip_len - (IP_HL(pi->ip4) * 4));
+    pi->s_ttl=pi->ip4->ip_ttl;
 }
 
 void parse_ip4(packetinfo *pi)
@@ -304,6 +305,7 @@ void prepare_ip6(packetinfo *pi)
     config.p_s.ip6_recv++;
     pi->af = AF_INET6;
     pi->ip6 = (ip6_header *) (pi->packet + pi->eth_hlen);
+    pi->s_ttl=pi->ip6->hop_lmt;
     pi->packet_bytes = pi->ip6->len;
 }
 
@@ -1142,7 +1144,7 @@ void usage()
     olog("   H: YMD-HMS Stamp S: Timestamp(s)  M: Timestamp(ms)  c: Client IP  \n");
     olog("   s: Server IP     C: Class         Q: Query          T: Type       \n");
     olog("   A: Answer        t: TTL           p: Protocol       n: Count\n");
-    olog("   h: hostname      L: QueryLength   l: AnswerLength\n");
+    olog("   h: hostname      L: QueryLength   l: AnswerLength   i: Server IP TTL\n");
     olog("\n");
     olog(" FLAGS:\n");
     olog("\n");

--- a/src/passivedns.h
+++ b/src/passivedns.h
@@ -386,6 +386,7 @@ typedef struct _packetinfo {
     uint16_t        packet_bytes;     /* Length of IP payload in packet */
     uint16_t        s_port;           /* Source port */
     uint16_t        d_port;           /* Destination port */
+    uint8_t         s_ttl;            /* Source IP  ttl */
     uint8_t         proto;            /* IP protocol type */
     uint8_t         sc;               /* SC_SERVER, SC_CLIENT or SC_UNKNOWN */
     tcp_header      *tcph;            /* TCP header struct pointer */


### PR DESCRIPTION
Add -i option to  log the IP TTL of Authority DNS, this feature can help to find the “DNS cache poisoning”。
usage:
```
passivedns -i any -l ~/dns.log -L ~/dnserr.log -N -Y -f HMhcspCQTAtni -X 46CDNPRSOFITMnfsxoryetaz -D
```
```
2017-04-11 15:12:18.567505||CentOS||123.56.98.121||216.239.36.10||53||udp||IN||www.google.com.||A||93.46.8.89||3004||1
2017-04-11 15:12:18.616379||CentOS||123.56.98.121||216.239.36.10||40||udp||IN||www.google.com.||A||172.217.27.132||300||1
2017-04-11 15:13:05.737046||CentOS||123.56.98.121||204.13.250.34||169||udp||IN||www.twitter.com.||A||46.82.174.68||2985||1
2017-04-11 15:13:05.752187||CentOS||123.56.98.121||204.13.250.34||53||udp||IN||www.twitter.com.||A||93.46.8.89||3022||1
2017-04-11 15:13:06.005611||CentOS||123.56.98.121||204.13.250.34||36||udp||IN||www.twitter.com.||CNAME||twitter.com.||600||1
2017-04-11 15:13:06.005611||CentOS||123.56.98.121||204.13.250.34||36||udp||IN||twitter.com.||A||104.244.42.193||1800||1
2017-04-11 15:13:06.005611||CentOS||123.56.98.121||204.13.250.34||36||udp||IN||twitter.com.||A||104.244.42.65||1800||1
```

there are three fake responses in this log, only  IP TTLs are different from real.

```
2017-04-11 15:12:18.567505||CentOS||123.56.98.121||216.239.36.10||53||udp||IN||www.google.com.||A||93.46.8.89||3004||1
...
2017-04-11 15:13:05.737046||CentOS||123.56.98.121||204.13.250.34||169||udp||IN||www.twitter.com.||A||46.82.174.68||2985||1
2017-04-11 15:13:05.752187||CentOS||123.56.98.121||204.13.250.34||53||udp||IN||www.twitter.com.||A||93.46.8.89||3022||1
```