### PR TITLE
Adding docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM alpine:3.6
+LABEL maintainer "Edward Bjarte Fjellskål <edward.fjellskaal@gmail.com>"
+
+RUN addgroup -S passivedns && adduser -S -g passivedns passivedns  
+RUN apk add --no-cache -t .build-deps build-base automake autoconf git \
+ && apk add --no-cache tini ldns-dev libpcap-dev \
+ && git clone -b '1.2.0' --single-branch --depth 1 https://github.com/gamelinux/passivedns /tmp/src \
+ && cd /tmp/src \
+ && autoreconf --install \
+ && ./configure \
+ && make \
+ && make install \
+ && /bin/rm -r /tmp/src \
+ && apk del .build-deps \
+ && mkdir /var/log/passivedns \
+ && chown passivedns:passivedns /var/log/passivedns \
+ && chmod +s /usr/local/bin/passivedns
+
+USER passivedns
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["/usr/local/bin/passivedns", "-l", "-", "-L", "-", "-C", "0", "-P", "0", "-X", "46CDNOLFIPRSTMndHfsxoryetaz"]


### PR DESCRIPTION
## What's all this then?

passivedns has been one of my favorite tools for DNS monitoring and has been in my toolbox for a number of years. Instead of maintaining this myself I figured I'd give back. 

Here's a `21.7 MB` alpine:3.6 container for passivedns.

I don't really have an opinion on default runtime options. I prefer to use passivedns as verbose as possible and let my logging pipeline handle any caching/duplication. This also helps keep memory usage low on kubernetes deployments.

Implementation of this container is up to the end user unless you'd like me to include a `docker-compose.yaml` or kubernetes deployment.

I haven't pushed this to dockerhub because, well, it's yours @gamelinux 😄 