### PR TITLE
Fix linux DLT_LINUX_SLL ifdef.

### DIFF
--- a/src/passivedns.c
+++ b/src/passivedns.c
@@ -144,7 +144,7 @@ void got_packet(u_char *useless, const struct pcap_pkthdr *pheader,
         case DLT_RAW:
             prepare_raw(pi);
             break;
-#ifdef DLT_LINUX_SSL
+#ifdef DLT_LINUX_SLL
         case DLT_LINUX_SLL:
             prepare_sll(pi);
             break;


### PR DESCRIPTION
Fix an ifdef typo breaking usage on linux with "-i any".
