### PR TITLE
add quiet mode option

### DIFF
--- a/src/passivedns.h
+++ b/src/passivedns.h
@@ -555,7 +555,12 @@ typedef struct _globalconfig {
 #define ISSET_INTERRUPT_DNS(config)     ((config).intr_flag & INTERRUPT_DNS)
 
 #define plog(fmt, ...) do{ fprintf(stdout, (fmt), ##__VA_ARGS__); }while(0)
-#define flog(h, fmt, ...) do{ fprintf(h, fmt, ##__VA_ARGS__); }while(0)
+#define flog(h, fmt, ...) \
+  do{ \
+    if (!(h == stdout && ISSET_CONFIG_QUIET(config))) \
+      fprintf(h, fmt, ##__VA_ARGS__); \
+  } \
+  while(0)
 #define olog(fmt, ...) do{ if(!(ISSET_CONFIG_QUIET(config))) fprintf(stdout, (fmt), ##__VA_ARGS__); }while(0)
 //#define DEBUG 1
 #ifdef DEBUG


### PR DESCRIPTION
This PR adds the new `-q` option, which enables a quiet mode -- no output is printed to stdout/stderr except for error messages.

Addresses #92. In the reported case one could use something like
```
passivedns -l - -q
```
to only get logged observations on stdout.