### PR TITLE
Added flag for Resource Record Type

### DIFF
--- a/pdns.patch
+++ b/pdns.patch
@@ -1,0 +1,57 @@
+--- search-pdns-original.pl	2017-08-24 19:18:52.859541254 -0400
++++ /usr/local/bin/search-pdns.pl	2018-03-21 14:49:24.217877474 -0400
+@@ -18,6 +18,7 @@
+ # along with this program; if not, write to the Free Software
+ # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ # ----------------------------------------------------------------------
++# Added Resource Record Type :  PJN 20180321
+ 
+ use strict;
+ use warnings;
+@@ -40,7 +41,7 @@
+ 
+ =head1 VERSION
+ 
+-    0.1.0
++    0.1.1
+ 
+ =head1 SYNOPSIS
+ 
+@@ -50,6 +51,7 @@
+ 
+     -s            : %IP/Domain%
+     -r            : Enables raw search
++    -t            : Resource Record Type (A, NS, MX, SOA, etc.)
+     --first-seen  : Date to search from in iso format (2010-01-01 etc.)
+     --last-seen   : Date to search to in iso format (2020-01-01 etc.)
+     --limit       : Limit on search results (100)
+@@ -73,6 +75,7 @@
+ our $FROM_DATE;
+ our $TO_DATE;
+ our $LIMIT;
++our $TYPE;
+ 
+ GetOptions(
+     'd=s'           => \$DEBUG,
+@@ -81,6 +84,7 @@
+     'first-seen=s'  => \$FROM_DATE,
+     'last-seen=s'   => \$TO_DATE,
+     'limit=s'       => \$LIMIT,
++    't=s'           => \$TYPE,
+ );
+ 
+ if ($SEARCH eq "") {
+@@ -131,6 +135,13 @@
+     }
+ }
+ 
++
++if (defined $TYPE) {
++       $QUERY1 = $QUERY1 . qq[AND maptype = '$TYPE' ];
++       $QUERY2 = $QUERY2 . qq[AND maptype = '$TYPE' ];
++}
++
++
+ $QUERY = $QUERY1 . qq[ UNION ] . $QUERY2;
+ 
+ if (defined $LIMIT && $LIMIT =~ /^([\d])+$/) {

--- a/tools/search-pdns.pl
+++ b/tools/search-pdns.pl
@@ -18,6 +18,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 # ----------------------------------------------------------------------
+# Added Resource Record Type :  hookol 20180321
 
 use strict;
 use warnings;
@@ -40,7 +41,7 @@ my $DLIMIT       =    100;
 
 =head1 VERSION
 
-    0.1.0
+    0.1.1
 
 =head1 SYNOPSIS
 
@@ -50,6 +51,7 @@ $ search-pdns.pl [options]
 
     -s            : %IP/Domain%
     -r            : Enables raw search
+    -t            : Resource Record Type (A, NS, MX, SOA, etc.)
     --first-seen  : Date to search from in iso format (2010-01-01 etc.)
     --last-seen   : Date to search to in iso format (2020-01-01 etc.)
     --limit       : Limit on search results (100)
@@ -73,6 +75,7 @@ our $SEARCH        = "%";
 our $FROM_DATE;
 our $TO_DATE;
 our $LIMIT;
+our $TYPE;
 
 GetOptions(
     'd=s'           => \$DEBUG,
@@ -81,6 +84,7 @@ GetOptions(
     'first-seen=s'  => \$FROM_DATE,
     'last-seen=s'   => \$TO_DATE,
     'limit=s'       => \$LIMIT,
+    't=s'           => \$TYPE,
 );
 
 if ($SEARCH eq "") {
@@ -130,6 +134,13 @@ if (defined $SEARCH) {
        $QUERY2 = $QUERY2 . qq[AND answer like '%$SEARCH%' ];
     }
 }
+
+
+if (defined $TYPE) {
+       $QUERY1 = $QUERY1 . qq[AND maptype = '$TYPE' ];
+       $QUERY2 = $QUERY2 . qq[AND maptype = '$TYPE' ];
+}
+
 
 $QUERY = $QUERY1 . qq[ UNION ] . $QUERY2;
 


### PR DESCRIPTION
search-pdns.pl --help
Usage:
    $ search-pdns.pl [options]

      OPTIONS:

        -s            : %IP/Domain%
        -r            : Enables raw search
        **-t            : Resource Record Type (A, NS, MX, SOA, etc.)**
        --first-seen  : Date to search from in iso format (2010-01-01 etc.)
        --last-seen   : Date to search to in iso format (2020-01-01 etc.)
        --limit       : Limit on search results (100)
