### PR TITLE
Add support for loopback/null devices

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -121,7 +121,7 @@ void dns_parser(packetinfo *pi)
         }
         dlog("[D] DNS Answer\n");
         /* Check the DNS TID */
-        if ((pi->cxt->plid == ldns_pkt_id(dns_pkt))) {
+        if (pi->cxt->plid == ldns_pkt_id(dns_pkt)) {
             dlog("[D] DNS Query TID match Answer TID: %d\n", pi->cxt->plid);
         }
         else {
@@ -372,7 +372,7 @@ int cache_dns_objects(packetinfo *pi, ldns_rdf *rdf_data,
                     to_offset = 5;
                 }
                 break;
-            
+
             case LDNS_RR_TYPE_NSEC:
                 if (config.dnsf & DNS_CHK_DNSSEC) {
                     offset = 0;

--- a/src/passivedns.c
+++ b/src/passivedns.c
@@ -66,6 +66,7 @@ uint8_t signal_reopen_log_files = 0;
 static void usage();
 static void show_version();
 void check_vlan (packetinfo *pi);
+void prepare_null (packetinfo *pi);
 void prepare_raw (packetinfo *pi);
 void prepare_sll (packetinfo *pi);
 void prepare_eth (packetinfo *pi);
@@ -141,6 +142,9 @@ void got_packet(u_char *useless, const struct pcap_pkthdr *pheader,
     config.inpacket = 1;
 
     switch (config.linktype) {
+        case DLT_NULL:
+            prepare_null(pi);
+            break;
         case DLT_RAW:
             prepare_raw(pi);
             break;
@@ -171,6 +175,16 @@ void got_packet(u_char *useless, const struct pcap_pkthdr *pheader,
     }
 
     config.inpacket = 0;
+}
+
+void prepare_null(packetinfo *pi)
+{
+    pi->eth_hlen = LOOPBACK_HDR_LEN;
+    if ((u_int32_t)*pi->packet == AF_INET) {
+        pi->eth_type = ETHERNET_TYPE_IP;
+    } else {
+        pi->eth_type = ETHERNET_TYPE_IPV6;
+    }
 }
 
 void prepare_raw(packetinfo *pi)

--- a/src/passivedns.h
+++ b/src/passivedns.h
@@ -54,6 +54,7 @@
 #define IP6_PROTO_ICMP                58
 
 #define SLL_HDR_LEN                   16
+#define LOOPBACK_HDR_LEN              4
 #define IP4_HEADER_LEN                20
 #define IP6_HEADER_LEN                40
 #define TCP_HEADER_LEN                20


### PR DESCRIPTION
I ran into a problem where a wireguard interface on FreeBSD wasn't supported.  Turns out libpcap treats many of these types of interfaces the sameish.   Enough that I *think* this will work generically for many virtual drivers (wireguard, loopback, openvpn).

This specifically may address #102.  At least it does address it on FreeBSD.

There's also a compiler warning fix about excess parenthesis.