### PR TITLE
Declare signal_reopen_log_files as a sig_atomic_t

### DIFF
--- a/src/passivedns.c
+++ b/src/passivedns.c
@@ -60,7 +60,7 @@
 /*  G L O B A L S  *** (or candidates for refactoring, as we say)***********/
 globalconfig config;
 connection *bucket[BUCKET_SIZE];
-uint8_t signal_reopen_log_files = 0;
+static volatile sig_atomic_t signal_reopen_log_files = 0;
 
 /*  I N T E R N A L   P R O T O T Y P E S  ***********************************/
 static void usage();


### PR DESCRIPTION
Strictly aligning to POSIX, signal_reopen_log_files must be a volatile sig_atomic_t.

«the behavior is undefined if the signal handler refers to any object other than errno with static storage duration other than by assigning a value to an object declared as volatile sig_atomic_t, or [calls a non-async-signal-safe function]»
https://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html#tag_15_04_03_03