### PR TITLE
Resolve deprecation warning for `pcap_lookupdev` used to find default interface

### DIFF
--- a/src/passivedns.c
+++ b/src/passivedns.c
@@ -1520,8 +1520,15 @@ int main(int argc, char *argv[])
     }
     else {
         /* Look up an available device if non specified */
-        if (config.dev == 0x0)
-            config.dev = pcap_lookupdev(config.errbuf);
+        if (config.dev == 0x0) {
+            pcap_if_t *alldevs;
+            if (0 != pcap_findalldevs(&alldevs, config.errbuf)) {
+                elog("[*] Error pcap_findalldevs: %s \n", config.errbuf);
+                exit(1);
+            }
+            config.dev = strdup(alldevs[0].name);
+            pcap_freealldevs(alldevs);
+        }
         olog("[*] Device: %s\n", config.dev);
 
         if ((config.handle = pcap_open_live(config.dev, SNAPLENGTH, config.promisc, 500,


### PR DESCRIPTION
Got an ugly warning while building on ubuntu 22.04 (`libpcap0.8-dev:amd64 1.10.1-4build1`) about pcap_lookupdev being deprecated.

Tested on
* ubuntu 22.04 amd64 (found wlp3s0)
* openbsd 7.1 amd64 (found em0)
* dietpi / debian 11 armv7l (found eth0)