### PR TITLE
Add tried-and-tested build instructions for Debian 12 and Macbook Pro 2023.

### DIFF
--- a/doc/INSTALL
+++ b/doc/INSTALL
@@ -28,7 +28,17 @@ Ubuntu
   # libdate-simple-perl is also needed for pdns2db.pl
   $ git clone git://github.com/gamelinux/passivedns.git
   $ cd passivedns/
-  $ autoreconf --install
+  $ autoreconf --install
+  $ ./configure
+  $ make
+
+Debian 12 (Bookworm)
+  $ sudo apt install git build-essential libldns-dev libpcap-dev automake autoconf
+  # libdate-simple-perl might be needed for pdns2db.pl if you're using it
+  $ sudo apt install libdate-simple-perl
+  $ git clone git://github.com/gamelinux/passivedns.git
+  $ cd passivedns/
+  $ autoreconf --install
   $ ./configure
   $ make
 
@@ -45,4 +55,8 @@ RedHat (RHEL 6u2 x86_64)
   $ autoreconf --install
   $ ./configure
   $ make
+
+
+
+
 

--- a/doc/INSTALL
+++ b/doc/INSTALL
@@ -23,6 +23,18 @@ OS X (using Homebrew for dependencies)
   $ ./configure
   $ make
 
+Macbook Pro 2023 running Sonoma 14.4.1 (using Homebrew for dependencies)
+  $ brew install automake autoconf ldns jansson openssl
+  $ export LDFLAGS="-L$(brew --prefix openssl)/lib $LDFLAGS"
+  $ export CPPFLAGS="-I$(brew --prefix openssl)/include $CPPFLAGS"
+  $ export LDFLAGS="-L$(brew --prefix ldns)/lib $LDFLAGS"
+  $ export CPPFLAGS="-I$(brew --prefix ldns)/include $CPPFLAGS"
+  $ git clone git://github.com/gamelinux/passivedns.git
+  $ cd passivedns/
+  $ autoreconf --install
+  $ ./configure
+  $ make
+
 Ubuntu
   $ sudo apt-get install git-core binutils-dev libldns1 libldns-dev libpcap-dev 
   # libdate-simple-perl is also needed for pdns2db.pl


### PR DESCRIPTION
Add to doc/INSTALL:

```
Debian 12 (Bookworm)
  $ sudo apt install git build-essential libldns-dev libpcap-dev automake autoconf
  # libdate-simple-perl might be needed for pdns2db.pl if you're using it
  $ sudo apt install libdate-simple-perl
  $ git clone git://github.com/gamelinux/passivedns.git
  $ cd passivedns/
  $ autoreconf --install
  $ ./configure
  $ make

Macbook Pro 2023 running Sonoma 14.4.1 (using Homebrew for dependencies)
  $ brew install automake autoconf ldns jansson openssl
  $ export LDFLAGS="-L$(brew --prefix openssl)/lib $LDFLAGS"
  $ export CPPFLAGS="-I$(brew --prefix openssl)/include $CPPFLAGS"
  $ export LDFLAGS="-L$(brew --prefix ldns)/lib $LDFLAGS"
  $ export CPPFLAGS="-I$(brew --prefix ldns)/include $CPPFLAGS"
  $ git clone git://github.com/gamelinux/passivedns.git
  $ cd passivedns/
  $ autoreconf --install
  $ ./configure
  $ make
```

Tested both, they work beautifully:

```
$ passivedns -i ens5 -l /var/log/passivedns.log -D
$ tail -f /var/log/passivedns.log 
1713291888.580818||10.16.34.183||10.16.32.2||IN||www.1234.com.||CNAME||redirect.telstra.net.||300||1
1713291888.580818||10.16.34.183||10.16.32.2||IN||redirect.telstra.net.||A||203.36.190.9||30||1
1713291898.171922||10.16.34.183||10.16.32.2||IN||www.example.com.||AAAA||2606:2800:220:1:248:1893:25c8:1946||300||1
1713291898.179097||10.16.34.183||10.16.32.2||IN||www.example.com.||A||93.184.216.34||300||1
```